### PR TITLE
python syntax error in setup.py, needed comma added to end of line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
 
     # Details
     url="https://github.com/sarathsp06/exotel-py",
-    download_url = 'https://github.com/sarathsp06/exotel-py/archive/v0.1.1.tar.gz'
+    download_url = 'https://github.com/sarathsp06/exotel-py/archive/v0.1.1.tar.gz',
     #
     license="LICENSE.txt",
     description="Python SDK for Exotel API",


### PR DESCRIPTION
Without comma at end of line in setup.py, python syntax error was being thrown when trying to run install.

$ python -m setup.py
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 151, in _run_module_as_main
    mod_name, loader, code, fname = _get_module_details(mod_name)
  File "/usr/lib/python2.7/runpy.py", line 101, in _get_module_details
    loader = get_loader(mod_name)
  File "/usr/lib/python2.7/pkgutil.py", line 464, in get_loader
    return find_loader(fullname)
  File "/usr/lib/python2.7/pkgutil.py", line 474, in find_loader
    for importer in iter_importers(fullname):
  File "/usr/lib/python2.7/pkgutil.py", line 430, in iter_importers
    __import__(pkg)
  File "setup.py", line 24
    license="LICENSE.txt",
          ^
SyntaxError: invalid syntax
